### PR TITLE
fix(lib): typo in error message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,6 @@ async function getOrCreateStore({ sealed, password, ttl }) {
       password,
       ttl,
     });
-    return store;
   } catch (err) {
     if (err.message === "Expired seal") {
       // if seal expires and it somehow reaches our servers (seal was stolen, bad clock)

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ async function getOrCreateStore({ sealed, password, ttl }) {
     if (err.message === "Expired seal") {
       // if seal expires and it somehow reaches our servers (seal was stolen, bad clock)
       // then we just start a new session over
-      return ironStore({ password, ttl });
+      return await ironStore({ password, ttl });
     }
 
     throw err;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ import cookie from "cookie";
 const timestampSkewSec = 60;
 
 function throwOnNoPassword() {
-  throw new Error("next-iron-sesion: Missing parameter `password`");
+  throw new Error("next-iron-session: Missing parameter `password`");
 }
 
 function computeCookieMaxAge(ttl) {
@@ -80,7 +80,7 @@ export default function withIronSession(
 
 async function getOrCreateStore({ sealed, password, ttl }) {
   try {
-    return await ironStore({
+    return ironStore({
       sealed,
       password,
       ttl,
@@ -89,7 +89,7 @@ async function getOrCreateStore({ sealed, password, ttl }) {
     if (err.message === "Expired seal") {
       // if seal expires and it somehow reaches our servers (seal was stolen, bad clock)
       // then we just start a new session over
-      return await ironStore({ password, ttl });
+      return ironStore({ password, ttl });
     }
 
     throw err;

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,11 +80,12 @@ export default function withIronSession(
 
 async function getOrCreateStore({ sealed, password, ttl }) {
   try {
-    return ironStore({
+    const store = await ironStore({
       sealed,
       password,
       ttl,
     });
+    return store;
   } catch (err) {
     if (err.message === "Expired seal") {
       // if seal expires and it somehow reaches our servers (seal was stolen, bad clock)

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,7 @@ export default function withIronSession(
 
 async function getOrCreateStore({ sealed, password, ttl }) {
   try {
-    const store = await ironStore({
+    return await ironStore({
       sealed,
       password,
       ttl,

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -11,7 +11,7 @@ test("withSession(handler) without a password", () => {
     expect(() => {
       withIronSession(handler);
     }).toThrowErrorMatchingInlineSnapshot(
-      `"next-iron-sesion: Missing parameter \`password\`"`,
+      `"next-iron-session: Missing parameter \`password\`"`,
     );
     done();
   });


### PR DESCRIPTION
**The PR is now only a fix for a typo problem.**

---------------

It's useless to add an `await` when we already return a promise.

See the eslint rule for example: https://eslint.org/docs/rules/no-return-await

(also fixed a small typo)

Edit: initially I removed both 2 `await`s but as the first one is required to check the error, I created a variable to remove the `return await`.

Tell me what do you think :)