### PR TITLE
feat(password): allow for multiple passwords (password rotation)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,6 @@
 import ironStore from "iron-store";
 import cookie from "cookie";
 
-// TODO: warn on no session usage
-// TODO: warn when session saved after end
-// TODO: warn when session not saved after set and req ended
-
 // default time allowed to check for iron seal validity when ttl passed
 // see https://hapi.dev/family/iron/api/?v=6.0.0#options
 const timestampSkewSec = 60;
@@ -86,8 +82,14 @@ async function getOrCreateStore({ sealed, password, ttl }) {
       ttl,
     });
   } catch (err) {
-    if (err.message === "Expired seal") {
-      // if seal expires and it somehow reaches our servers (seal was stolen, bad clock)
+    if (
+      err.message === "Expired seal" ||
+      err.message === "Bad hmac value" ||
+      err.message === "Cannot find password: "
+    ) {
+      // if seal expires or
+      // if seal is not valid (encrypted using a different password, when passwords are updated) or
+      // if we can't find back the password in the seal
       // then we just start a new session over
       return await ironStore({ password, ttl });
     }

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -56,25 +56,25 @@ test("withSession(({req, res}) => {}, {password})", () => {
   return new Promise((done) => {
     const handler = ({ req, res }) => {
       expect(req).toMatchInlineSnapshot(`
-Object {
-  "headers": Object {
-    "cookie": "ssr=1",
-  },
-  "session": Object {
-    "destroy": [Function],
-    "get": [Function],
-    "save": [Function],
-    "set": [Function],
-    "setFlash": [Function],
-    "unset": [Function],
-  },
-}
-`);
+        Object {
+          "headers": Object {
+            "cookie": "ssr=1",
+          },
+          "session": Object {
+            "destroy": [Function],
+            "get": [Function],
+            "save": [Function],
+            "set": [Function],
+            "setFlash": [Function],
+            "unset": [Function],
+          },
+        }
+      `);
       expect(res).toMatchInlineSnapshot(`
-Object {
-  "json": [Function],
-}
-`);
+        Object {
+          "json": [Function],
+        }
+      `);
       done();
     };
     const wrappedHandler = withIronSession(handler, { password });
@@ -130,10 +130,10 @@ test("req.session.unset", () => {
     const handler = (req) => {
       req.session.set("state", { id: 20 });
       expect(req.session.get("state")).toMatchInlineSnapshot(`
-Object {
-  "id": 20,
-}
-`);
+        Object {
+          "id": 20,
+        }
+      `);
       req.session.unset("state");
       expect(req.session.get("state")).toMatchInlineSnapshot(`undefined`);
       done();
@@ -161,7 +161,7 @@ test("req.session.save creates a seal and stores it in a cookie", () => {
 
       const cookie = headerValue[0];
       const seal = cookie.split(";")[0].split("=")[1];
-      expect(seal).toHaveLength(262);
+      expect(seal).toHaveLength(263);
 
       const cookieParams = cookie.split(";").slice(1).join(";");
       expect(cookieParams).toMatchInlineSnapshot(
@@ -185,12 +185,12 @@ test("withSession((req, res) => {}, {password}) with existing session (SG)", asy
   return new Promise((done) => {
     const handler = (req) => {
       expect(req.session.get()).toMatchInlineSnapshot(`
-Object {
-  "user": Object {
-    "id": 3,
-  },
-}
-`);
+        Object {
+          "user": Object {
+            "id": 3,
+          },
+        }
+      `);
       done();
     };
     const wrappedHandler = withIronSession(handler, { password });
@@ -210,12 +210,12 @@ test("withSession(({req, res}) => {}, {password}) with existing session (SSR)", 
   return new Promise((done) => {
     const handler = ({ req }) => {
       expect(req.session.get()).toMatchInlineSnapshot(`
-Object {
-  "user": Object {
-    "id": 3,
-  },
-}
-`);
+        Object {
+          "user": Object {
+            "id": 3,
+          },
+        }
+      `);
       done();
     };
     const wrappedHandler = withIronSession(handler, { password });
@@ -259,13 +259,13 @@ test("req.session.destroy", () => {
       req.session.destroy();
       expect(req.session.get()).toMatchInlineSnapshot(`Object {}`);
       expect(res.setHeader.mock.calls[0]).toMatchInlineSnapshot(`
-Array [
-  "set-cookie",
-  Array [
-    "__ironSession=; Max-Age=0; Path=/; HttpOnly; Secure; SameSite=Lax",
-  ],
-]
-`);
+        Array [
+          "set-cookie",
+          Array [
+            "__ironSession=; Max-Age=0; Path=/; HttpOnly; Secure; SameSite=Lax",
+          ],
+        ]
+      `);
       done();
     };
     const wrappedHandler = withIronSession(handler, { password, ttl: 0 });
@@ -292,10 +292,10 @@ test("When trying to use an expired seal", async () => {
 
       const handler = async (req) => {
         expect(req.session.get("user")).toMatchInlineSnapshot(`
-Object {
-  "id": 20,
-}
-`);
+          Object {
+            "id": 20,
+          }
+        `);
         done();
       };
       const wrappedHandler = withIronSession(handler, { password, ttl });
@@ -334,7 +334,7 @@ Object {
   return whenNotExpired().then(whenExpired).then(clear);
 });
 
-test("It throws Iron errors when passing a wrong password", async () => {
+test("It throws Iron errors when passing a wrong password (password length must be >= 32)", async () => {
   const handler = async (req, res) => {
     await req.session.save();
     const headerValue = res.setHeader.mock.calls[0][1];
@@ -377,6 +377,86 @@ test("when no cookies at all", () => {
     wrappedHandler(
       {
         headers: {},
+      },
+      {},
+    );
+  });
+});
+
+test("When trying to use a wrong seal (example: password was updated server-side without rotation)", async () => {
+  const firstPassword = "Bb0EyombqcDK58k870btymbGJrgZFrN2";
+  const secondPassword = "182XhM1mAzottfvzPMN0nh20HMwZprBc";
+
+  const store = await ironStore({ password: firstPassword });
+  store.set("user", { id: 20 });
+  const seal = await store.seal();
+
+  return new Promise((done) => {
+    const handler = (req) => {
+      expect(req.session.get("user")).toMatchInlineSnapshot(`undefined`);
+      done();
+    };
+    const wrappedHandler = withIronSession(handler, {
+      password: secondPassword,
+    });
+    wrappedHandler(
+      {
+        headers: { cookie: `__ironSession=${seal}` },
+      },
+      {},
+    );
+  });
+});
+
+test("moving from <=3.1.2 seals to multi passwords creates a new session", async () => {
+  return new Promise((done) => {
+    const handler = (req) => {
+      expect(req.session.get("user")).toMatchInlineSnapshot(`undefined`);
+      done();
+    };
+    const wrappedHandler = withIronSession(handler, {
+      password: [{ id: 1, password }],
+    });
+    wrappedHandler(
+      {
+        headers: {
+          cookie:
+            "__ironSession=Fe26.2**4e769b9b7b921621ed5658cfc0d7d8e267dc8ee93663c2803c257b31111394e3*jRXOJHmt_BDG9nNTXcVRXQ*UHpK9GYp7SXTiEsxTzTUq_tQD_-ZUp7PguEXy-bRFuBE4fW74-9wm9UtlWO2rlwB**d504d6d197d183efec0ae6d3c2378c43048c8752d6c3c591c92289ed01142b3c*3NG2fCo8A53CXPU8rEAMnDB7X9UkwzTaHieumPBqyTw",
+        },
+      },
+      {},
+    );
+  });
+});
+
+test("Password rotation", async () => {
+  const firstPassword = [
+    { id: 1, password: "BcTv8NKLVfGcTt18HqGf2DhEnmJrLbNU" },
+  ];
+  const secondPassword = [
+    { id: 2, password: "scKVNPWFippYjA3tRjJPuPnK7ocj4Vnn" },
+    { id: 1, password: "BcTv8NKLVfGcTt18HqGf2DhEnmJrLbNU" },
+  ];
+
+  const store = await ironStore({ password: firstPassword });
+  store.set("user", { id: 20 });
+  const seal = await store.seal();
+
+  return new Promise((done) => {
+    const handler = (req) => {
+      expect(req.session.get("user")).toMatchInlineSnapshot(`
+        Object {
+          "id": 20,
+        }
+      `);
+      done();
+    };
+    const wrappedHandler = withIronSession(handler, {
+      password: secondPassword,
+    });
+    wrappedHandler(
+      {
+        headers: { cookie: `__ironSession=${seal}` },
       },
       {},
     );

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "clone": "^2.1.2",
     "cookie": "^0.4.0",
-    "iron-store": "^1.2.0"
+    "iron-store": "^1.3.0"
   },
   "devDependencies": {
     "@babel/cli": "7.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4140,10 +4140,10 @@ ip@1.1.5:
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
-iron-store@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/iron-store/-/iron-store-1.2.0.tgz#a446c110aa71fa7c3a78fdbad182fe4be0544298"
-  integrity sha512-wt1cW5WjEa0gzQ3GsVujjCH6Rtn2skn6CXZcG6n3PWM+8QtsGqkpI2rb/phdTnpH23JgZudckCLNEg3yYOTA6g==
+iron-store@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/iron-store/-/iron-store-1.3.0.tgz#bcd8c0a5b0d89b27de4ce4ee7979574f8e903b89"
+  integrity sha512-Ics0Xy/1TTjOhZFLkarOpWfXp4TJ7foiKBFC/aXJH1bKwafNKrEhrHNeHyA/Jqx57tlhpIbGoNC3RUB+rRIz8Q==
   dependencies:
     "@hapi/iron" "^6.0.0"
     clone "^2.1.2"


### PR DESCRIPTION
Example usage:

```js
export default withIronSession(handler, {
  password: [
    {
      id: 2,
      password: "another_password_at_least_32_characters_long",
    },
    {
      id: 1,
      password: "complex_password_at_least_32_characters_long",
    },
  ],
});
```

fixes #69