### PR TITLE
Generate typescript declaration file.

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,59 @@
+export type SessionOptions = {
+  /** Name of the cookie
+   *
+   * Required */
+  cookieName: string;
+
+  /** The options for the cookie
+   *
+   * Default: {
+      httpOnly: true,
+      path: "/",
+      sameSite: 'lax'
+      secure: true
+     } */
+  cookieOptions?: CookieOptions;
+
+  /** Password of the cookie
+   *
+   *  Required */
+  password: string;
+
+  /** Time to live in seconds.
+  *
+  * Default: 15 days 8 */
+  ttl?: number;
+};
+
+export type Handler = (req: any, res: any) => any;
+
+export type CookieOptions = {
+  /** Forbids JavaScript from accessing the cookie.
+   * For example, through the Document.cookie property, the XMLHttpRequest API, or the Request API.
+   * This mitigates attacks against cross-site scripting (XSS).
+   *
+   * Default: true */
+  httpOnly?: boolean;
+
+  /** A path that must exist in the requested URL, or the browser won't send the Cookie header.
+   *
+   * Default: "/" */
+  path?: string;
+
+  /** Asserts that a cookie must not be sent with cross-origin requests, providing some protection against cross-site request forgery attacks
+    *
+    * Default: "lax" */
+  sameSite?: 'none' | 'lax' | 'strict';
+
+  /** A secure cookie is only sent to the server when a request is made with the https: scheme.
+   *
+   * Default: true */
+  secure?: boolean;
+};
+
+
+export function applySession(req: any, res: any, sessionOptions: SessionOptions): Promise<void>;
+
+export function ironSession(sessionOptions: SessionOptions): (req: any, res: any, next: any) => void;
+
+export function withIronSession(handler: Handler, sessionOptions: SessionOptions): (...args: any[]) => Promise<any>;


### PR DESCRIPTION
+ Exposed functionality has jsdoc
+ Typescript generates declaration file from jsdoc for index.js
+ lib/index.d.ts is tracked as it's now part of contract for exported functionality and helps spotting changes to the contract.

- Declarations are are not built as part of build script due to limited knowledge of yarn, as well as  leaving it to your choice if preferred to be part of build.
