### PR TITLE
docs(Readme): header link redirecting to 404 page

### DIFF
--- a/examples/next.js/README.md
+++ b/examples/next.js/README.md
@@ -1,4 +1,4 @@
-# Example Next.js application using [`next-iron-session`](https://github.com/vvo/next-iron/session)
+# Example Next.js application using [`next-iron-session`](https://github.com/vvo/next-iron-session)
 
 This example creates an authentication system that uses a **signed and encrypted cookie to store session data**. It relies on [`next-iron-session`](https://github.com/vvo/next-iron-session).
 


### PR DESCRIPTION
The link in was "https://github.com/vvo/next-iron/session" when it should be "https://github.com/vvo/next-iron-session