### PR TITLE
fix(cookie): handle previously set-cookie headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,8 @@ export async function applySession(
           `next-iron-session: Cookie length is too big ${cookieValue.length}, browsers will refuse it`,
         );
       }
-      res.setHeader("set-cookie", [cookieValue]);
+      const existingSetCookie = [res.getHeader("set-cookie") || []].flat();
+      res.setHeader("set-cookie", [...existingSetCookie, cookieValue]);
       return cookieValue;
     },
     destroy() {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -167,6 +167,7 @@ test("req.session.save creates a seal and stores it in a cookie", () => {
       },
       {
         setHeader: jest.fn(),
+        getHeader: jest.fn(),
       },
     );
   });
@@ -242,6 +243,7 @@ test("When ttl is 0, maxAge have a specific value", () => {
       },
       {
         setHeader: jest.fn(),
+        getHeader: jest.fn(),
       },
     );
   });
@@ -615,6 +617,57 @@ test("it throws when cookie length is too big", () => {
       },
       {
         setHeader: jest.fn(),
+      },
+    );
+  });
+});
+
+test("it handles previously set cookies (single value)", () => {
+  return new Promise((done) => {
+    const handler = async (req, res) => {
+      await req.session.save();
+
+      const headerValue = res.setHeader.mock.calls[0][1];
+      expect(headerValue.length).toBe(2);
+      expect(headerValue[0]).toBe("existingCookie=value");
+      done();
+    };
+    const wrappedHandler = withIronSession(handler, { password, cookieName });
+    wrappedHandler(
+      {
+        headers: { cookie: "" },
+      },
+      {
+        setHeader: jest.fn(),
+        getHeader: function () {
+          return "existingCookie=value";
+        },
+      },
+    );
+  });
+});
+
+test("it handles previously set cookies (multiple values)", () => {
+  return new Promise((done) => {
+    const handler = async (req, res) => {
+      await req.session.save();
+
+      const headerValue = res.setHeader.mock.calls[0][1];
+      expect(headerValue.length).toBe(3);
+      expect(headerValue[0]).toBe("existingCookie=value");
+      expect(headerValue[1]).toBe("anotherCookie=value2");
+      done();
+    };
+    const wrappedHandler = withIronSession(handler, { password, cookieName });
+    wrappedHandler(
+      {
+        headers: { cookie: "" },
+      },
+      {
+        setHeader: jest.fn(),
+        getHeader: function () {
+          return ["existingCookie=value", "anotherCookie=value2"];
+        },
       },
     );
   });


### PR DESCRIPTION
This commit fixes a case where previous set-cookie headers were ignored through
the request lifecycle. This is now fixed and handles both single and multiple
set-cookie header values. Since in Node.js you can do:

res.setHeader("set-cookie", "name=value"); and
res.setHeader("set-cookie", ["name=value", "name2=value2"])

fixes #112