### PR TITLE
Replaced .flat() with alternative

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ export async function applySession(
           `next-iron-session: Cookie length is too big ${cookieValue.length}, browsers will refuse it`,
         );
       }
-      const existingSetCookie = [res.getHeader("set-cookie") || []].flat();
+      const existingSetCookie = [res.getHeader('set-cookie') || []].reduce((acc, val) => acc.concat(val), []); //Flat array
       res.setHeader("set-cookie", [...existingSetCookie, cookieValue]);
       return cookieValue;
     },
@@ -77,7 +77,7 @@ export async function applySession(
         ...cookieOptions,
         maxAge: 0,
       });
-      const existingSetCookie = [res.getHeader("set-cookie") || []].flat();
+      const existingSetCookie = [res.getHeader('set-cookie') || []].reduce((acc, val) => acc.concat(val), []); //Flat array
       res.setHeader("set-cookie", [...existingSetCookie, cookieValue]);
     },
   };


### PR DESCRIPTION
Replaced use of flat method with alternative to support previous version of node as NextJs, specially v10.13.0 [https://nextjs.org/docs#system-requirements](url).

Alternative supports only one level deep flattening of cookie array, because I think that's the type of res.getHeader('set-cookie')  and it doesn't get any deeper.