### PR TITLE
feat: reset cookie when its has multiple values

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -19,6 +19,11 @@ export type SessionOptions = {
    *  Required */
   password: string | { id: number; password: string }[];
 
+  /** Domains to reset when duplicate cookies are found
+   *
+   * Default: null */
+  resetDomains?: Array<?string>;
+
   /** Time to live in seconds.
    *
    * Default: 15 days 8 */

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,24 @@ function getCookieOptions({ userCookieOptions, ttl }) {
   };
 }
 
+function resetDomains(cookies, cookieName, cookieOptions, domains, req) {
+  if (
+    cookieOptions.domain &&
+    Array.isArray(domains) &&
+    (req.headers.cookie || "").split(cookieName).length > 2
+  ) {
+    for (const domain of domains) {
+      cookies.push(
+        cookie.serialize(cookieName, "", {
+          ...cookieOptions,
+          maxAge: 0,
+          domain: domain,
+        }),
+      );
+    }
+  }
+}
+
 export async function applySession(
   req,
   res,
@@ -46,6 +64,7 @@ export async function applySession(
     cookieName = throwOnNoCookieName(),
     password = throwOnNoPassword(),
     cookieOptions: userCookieOptions = {},
+    resetDomains: userResetDomains = null,
   },
 ) {
   const cookieOptions = getCookieOptions({ userCookieOptions, ttl });
@@ -68,18 +87,23 @@ export async function applySession(
           `next-iron-session: Cookie length is too big ${cookieValue.length}, browsers will refuse it`,
         );
       }
-      const existingSetCookie = flat([res.getHeader("set-cookie") || []]);
-      res.setHeader("set-cookie", [...existingSetCookie, cookieValue]);
+      const cookies = flat([res.getHeader("set-cookie") || []]);
+      cookies.push(cookieValue);
+      resetDomains(cookies, cookieName, cookieOptions, userResetDomains, req);
+      res.setHeader("set-cookie", cookies);
       return cookieValue;
     },
     destroy() {
       store.clear();
-      const cookieValue = cookie.serialize(cookieName, "", {
-        ...cookieOptions,
-        maxAge: 0,
-      });
-      const existingSetCookie = flat([res.getHeader("set-cookie") || []]);
-      res.setHeader("set-cookie", [...existingSetCookie, cookieValue]);
+      const cookies = flat([res.getHeader("set-cookie") || []]);
+      cookies.push(
+        cookie.serialize(cookieName, "", {
+          ...cookieOptions,
+          maxAge: 0,
+        }),
+      );
+      resetDomains(cookies, cookieName, cookieOptions, userResetDomains, req);
+      res.setHeader("set-cookie", cookies);
     },
   };
 
@@ -93,6 +117,7 @@ export function withIronSession(
     cookieName = throwOnNoCookieName(),
     password = throwOnNoPassword(),
     cookieOptions = {},
+    resetDomains = null,
   },
 ) {
   return async function withIronSessionHandler(...args) {
@@ -100,7 +125,13 @@ export function withIronSession(
     const req = handlerType === "api" ? args[0] : args[0].req;
     const res = handlerType === "api" ? args[1] : args[0].res;
 
-    await applySession(req, res, { ttl, cookieName, password, cookieOptions });
+    await applySession(req, res, {
+      ttl,
+      cookieName,
+      password,
+      cookieOptions,
+      resetDomains,
+    });
 
     return withIronSessionWrapperHandler(...args);
   };
@@ -111,9 +142,16 @@ export function ironSession({
   cookieName = throwOnNoCookieName(),
   password = throwOnNoPassword(),
   cookieOptions = {},
+  resetDomains = null,
 }) {
   return function (req, res, next) {
-    applySession(req, res, { ttl, cookieName, password, cookieOptions })
+    applySession(req, res, {
+      ttl,
+      cookieName,
+      password,
+      cookieOptions,
+      resetDomains,
+    })
       .then(() => {
         next();
       })


### PR DESCRIPTION
This PR adds a list of domains on which the cookie needs to be removed when the cookie have multiple values.

This mainly targeted when moving from a single domain website (with no domain option) to a multiples subdomains website (with the domain option as `domain.com`).
Without `resetDomains`, the cookie will have conflicting values on `www.domain.com` and `domain.com`. The old cookie won't be removed by the newer cookie.
With `resetDomains: [null]`, the older cookie (with default domain, `www.domain.com`) is been removed only if it's detecting that the cookie has multiple values. (It would require a double login or double logout)