### PR TITLE
docs(example): Amend import example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ app.use(ironSession({ ...options }));
 Allows you to use this module the way you want as long as you have access to `req` and `res`.
 
 ```js
-import { applySession } from "next-session";
+import { applySession } from "next-iron-session";
 
 await applySession(req, res, options);
 ```


### PR DESCRIPTION
Instructions in README under **applySession** were incorrectly displaying an unintended example import from `next-session` instead of `next-iron-session`.