### PR TITLE
fix(TypeScript): correct typing on Session

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,7 +28,7 @@ export type SessionOptions = {
 export type Handler = (req: any, res: any) => any;
 
 export type Session = {
-  set: <T = any>(name: string, value: T) => void;
+  set: <T = any>(name: string, value: T) => T;
   get: <T = any>(name: string) => T | undefined;
   unset: (name: string) => void;
   destroy: () => void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -32,7 +32,7 @@ export type Session = {
   get: <T = any>(name: string) => T | undefined;
   unset: (name: string) => void;
   destroy: () => void;
-  save: () => Promise<void>;
+  save: () => Promise<string>;
 };
 
 export type CookieOptions = {


### PR DESCRIPTION
I was trying out the library in a TypeScript Next.js app and I thought it was weird that Session.set didn't return the value that was passed in. I realised that it actually does after digging in a little bit, so this PR is primarily to fix that.

Additionally, I thought I'd check the other types on the Session and also found that Session.save returns the cookie header value as a string.