### PR TITLE
feat(TypeScript to Handler): next types to the handler function

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,5 @@
+import { IncomingMessage, ServerResponse } from "http";
+
 export type SessionOptions = {
   /** Name of the cookie
    *
@@ -25,11 +27,50 @@ export type SessionOptions = {
   ttl?: number;
 };
 
-export type Handler = (req: any, res: any) => any;
+/**
+ * This the NextApiRequest with Session type and NextApiResponse
+ * This is stright from Next.js 'next/next-server/util.d.ts'
+ */
+type Env = {
+  [key: string]: string;
+};
+export interface WithNextApiRequest extends IncomingMessage {
+  query: {
+    [key: string]: string | string[];
+  };
+  cookies: {
+    [key: string]: string;
+  };
+  body: any;
+  env: Env;
+  preview?: boolean;
+  previewData?: any;
+  session: Session;
+}
+type Send<T> = (body: T) => void;
+export type NextApiResponse<T = any> = ServerResponse & {
+  send: Send<T>;
+  json: Send<T>;
+  status: (statusCode: number) => NextApiResponse<T>;
+  redirect(url: string): NextApiResponse<T>;
+  redirect(status: number, url: string): NextApiResponse<T>;
+
+  setPreviewData: (
+    data: object | string,
+    options?: {
+      maxAge?: number;
+    },
+  ) => NextApiResponse<T>;
+  clearPreviewData: () => NextApiResponse<T>;
+};
+export type Handler<T = any> = (
+  req: WithNextApiRequest,
+  res: NextApiResponse<T>,
+) => void | Promise<void>;
 
 export type Session = {
   set: <T = any>(name: string, value: T) => T;
-  get: <T = any>(name: string) => T | undefined;
+  get: <T = any>(name?: string) => T | undefined;
   unset: (name: string) => void;
   destroy: () => void;
   save: () => Promise<string>;

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   ],
   "scripts": {
     "build": "babel lib/ -d dist/ --source-maps --ignore '**/*.test.js' --delete-dir-on-start",
-    "format": "prettier --write '**/*.*' && eslint . --fix",
-    "lint": "prettier --check '**/*.*' && eslint .",
+    "format": "prettier --write **/*.* && eslint . --fix",
+    "lint": "prettier --check **/*.* && eslint .",
     "prepublishOnly": "yarn build",
     "semantic-release": "semantic-release",
     "test": "jest --coverage && yarn lint"


### PR DESCRIPTION
Closes #298
now it can be used like this:
```typescript
import {  Handler, withIronSession } from 'next-iron-session'

export default function withSession(handler:Handler):(...args:Record<string, unknown>[]) => Promise<void> {
  return withIronSession(handler, {
    password: '',
    cookieName: 'token',
    cookieOptions: {
      // the next line allows to use the session in non-https environments like
      // Next.js dev mode (http://localhost:3000)
      secure: false,
      httpOnly: true,
      path: '/',
      maxAge: 1800,
      
    sameSite: 'strict',
    },
  })
}
```