### PR TITLE
fix: typo `environment`

### DIFF
--- a/examples/next.js/lib/session.js
+++ b/examples/next.js/lib/session.js
@@ -6,7 +6,7 @@ export default function withSession(handler) {
     password: process.env.SECRET_COOKIE_PASSWORD,
     cookieName: "next-iron-session/examples/next.js",
     cookieOptions: {
-      // the next line allows to use the session in non-https environements like
+      // the next line allows to use the session in non-https environments like
       // Next.js dev mode (http://localhost:3000)
       secure: process.env.NODE_ENV === "production",
     },


### PR DESCRIPTION
typo.
