### PR TITLE
Fix README - destroy() returns void, not promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ _Table of contents:_
   - [req.session.get(name)](#reqsessiongetname)
   - [req.session.unset(name)](#reqsessionunsetname)
   - [req.session.save() => promise](#reqsessionsave--promise)
-  - [req.session.destroy() => promise](#reqsessiondestroy--promise)
+  - [req.session.destroy()](#reqsessiondestroy)
 - [FAQ](#faq)
   - [Why use pure 🍪 cookies for sessions?](#why-use-pure--cookies-for-sessions)
   - [What are the drawbacks?](#what-are-the-drawbacks)
@@ -292,7 +292,7 @@ await applySession(req, res, options);
 
 ### req.session.save() => promise
 
-### req.session.destroy() => promise
+### req.session.destroy()
 
 Note: If you use `req.session.destroy()` in an API route, you need to make sure this route will not be cached. To do so, either call this route via a POST request `fetch("/api/logout", { method: "POST" })` or add `cache-control: no-store, max-age=0` to its response.
 


### PR DESCRIPTION
The README documentation mentions that `destroy()` returns a promise. However, looking at the code, it only performs synchronous tasks. The TS types also define `destroy()` as returning `void`.