### PR TITLE
feat(TypeScript): IronHandler

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { Request, Response } from "express";
 import type { CookieSerializeOptions } from "cookie";
+
+type ExpressRequestWithSession = Request & { session: Session };
+type NextApiRequestWithSession = NextApiRequest & { session: Session };
+export type IronRequest = ExpressRequestWithSession | NextApiRequestWithSession;
+export type IronResponse = Response | NextApiResponse;
+
+export type IronHandler<IronRequest, IronResponse> = (
+  req: IronRequest,
+  res: IronResponse,
+) => any;
 
 export type SessionOptions = {
   /** Name of the cookie
@@ -27,11 +39,6 @@ export type SessionOptions = {
   ttl?: number;
 };
 
-export type Handler<Req, Res> = (
-  req: Req & { session: Session },
-  res: Res,
-) => any;
-
 export type Session = {
   set: <T = any>(name: string, value: T) => T;
   get: <T = any>(name: string) => T | undefined;
@@ -51,6 +58,6 @@ export function ironSession(
 ): (req: any, res: any, next: any) => void;
 
 export function withIronSession(
-  handler: Handler,
+  handler: IronHandler<IronRequest, IronResponse>,
   sessionOptions: SessionOptions,
 ): (...args: any[]) => Promise<any>;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -12,6 +12,8 @@ export type IronHandler<IronRequest, IronResponse> = (
   res: IronResponse,
 ) => any;
 
+export type Handler = IronHandler<IronRequest, IronResponse>;
+
 export type SessionOptions = {
   /** Name of the cookie
    *

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-import type { CookieSerializeOptions } from "@types/cookie";
+import type { CookieSerializeOptions } from "cookie";
 
 export type SessionOptions = {
   /** Name of the cookie

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -27,7 +27,10 @@ export type SessionOptions = {
   ttl?: number;
 };
 
-export type Handler = (req: any, res: any) => any;
+export type Handler<Req, Res> = (
+  req: Req & { session: Session },
+  res: Res,
+) => any;
 
 export type Session = {
   set: <T = any>(name: string, value: T) => T;

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     ]
   },
   "dependencies": {
-    "@types/cookie": "^0.4.0",
     "array.prototype.flat": "^1.2.4",
     "clone": "^2.1.2",
     "cookie": "^0.4.1",
@@ -90,6 +89,7 @@
     "@babel/cli": "7.13.16",
     "@babel/core": "7.14.0",
     "@babel/preset-env": "7.14.1",
+    "@types/express": "^4.17.12",
     "@types/jest": "26.0.20",
     "babel-eslint": "10.1.0",
     "babel-jest": "26.6.3",
@@ -98,8 +98,10 @@
     "eslint-plugin-jest": "24.1.5",
     "eslint-plugin-react": "7.22.0",
     "eslint-plugin-react-hooks": "4.2.0",
+    "express": "^4.17.1",
     "jest": "26.6.3",
     "jest-date-mock": "1.0.8",
+    "next": "^10.2.3",
     "prettier": "2.2.1",
     "prettier-plugin-packagejson": "2.2.10",
     "semantic-release": "17.4.0"


### PR DESCRIPTION
this PR creates types for IronRequest, IronResponse, and IronHandler<Req, Res>, where IronRequest is like NextRequest | ExpressRequest.

I would love to have lumped this in with https://github.com/vvo/next-iron-session/pull/354

but I chose not to because this PR includes dev dependency on both Express and Next, which I consider to be worth segmenting out in case there is concern about it.

this PR chains (depends on prior merging of) the above-mentioned PR

Note that @types/next is deprecated; they officially recommend direct dependency on Next
